### PR TITLE
pelaaja health bar ja damagen ottaminen

### DIFF
--- a/enemy.gd
+++ b/enemy.gd
@@ -1,1 +1,0 @@
-extends Sprite2D

--- a/scenes/mob.tscn
+++ b/scenes/mob.tscn
@@ -8,8 +8,7 @@
 radius = 531.069
 
 [node name="Mob" type="CharacterBody2D"]
-collision_layer = 2
-collision_mask = 3
+collision_layer = 3
 script = ExtResource("1_5miok")
 
 [node name="enemy" type="Sprite2D" parent="."]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://bto2uwkcee1bu"]
+[gd_scene load_steps=8 format=3 uid="uid://bto2uwkcee1bu"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_dosvn"]
 [ext_resource type="Texture2D" uid="uid://bnr72cim65ls3" path="res://assets/images/mushroom.png" id="2_6ik14"]
@@ -6,6 +6,24 @@
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_pkjvo"]
 radius = 37.054
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_0yqjv"]
+radius = 46.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_04oqh"]
+bg_color = Color(0.25098, 0.27451, 0.321569, 0.764706)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x2mu8"]
+bg_color = Color(0.188235, 0.764706, 0.270588, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
 
 [node name="Player" type="CharacterBody2D"]
 script = ExtResource("1_dosvn")
@@ -24,3 +42,24 @@ shape = SubResource("CircleShape2D_pkjvo")
 [node name="Gun" parent="." instance=ExtResource("3_gyfc5")]
 unique_name_in_owner = true
 position = Vector2(49, 36)
+
+[node name="HurtBox" type="Area2D" parent="."]
+unique_name_in_owner = true
+collision_layer = 0
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
+position = Vector2(3, -1)
+shape = SubResource("CircleShape2D_0yqjv")
+debug_color = Color(0.75318, 0.424213, 0.464807, 0.42)
+
+[node name="ProgressBar" type="ProgressBar" parent="."]
+unique_name_in_owner = true
+offset_left = -96.0
+offset_top = -114.0
+offset_right = 97.0
+offset_bottom = -82.0
+theme_override_styles/background = SubResource("StyleBoxFlat_04oqh")
+theme_override_styles/fill = SubResource("StyleBoxFlat_x2mu8")
+value = 100.0
+show_percentage = false

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,8 +1,28 @@
 extends CharacterBody2D
 
+signal health_depleted 
+
+#Pelaajan health
+var health = 100.0
+	
+
+
 # Pelaajahahmon liike
 func _physics_process(delta: float) -> void:
 	var direction = Input.get_vector("move_left", "move_right", "move_up", "move_down")
 	# Hahmon nopeus
 	velocity = direction * 650
 	move_and_slide()
+
+#Pelaajan ottama damagen määrittelyä
+	const DAMAGE_RATE = 5.0
+	var overlapping_mobs = %HurtBox.get_overlapping_bodies()
+	if overlapping_mobs.size() > 0:
+		health -= DAMAGE_RATE * overlapping_mobs.size() * delta
+		%ProgressBar.value = health
+		if health <= 0:
+			health_depleted.emit()
+			
+	
+	
+	


### PR DESCRIPTION
Lisätty pelaajahahmolle health bar ja määritelty pelaajan healthiksi 100. Health bar on väriltään vihreä ja taustaväriltä tummanharmaa. health bar sijaitsee pelaajahamon yläpuolella. Määritelty myös, että pelaaja ottaa vahinkoa 5 per sekunti per vihollinen.
Poistettu myös enemy.gd script mikä oli tuplana pelitiedostoissa